### PR TITLE
Changed build.gradle to use commhandler4modbus V1.0.1.

### DIFF
--- a/SampleCommunicator/build.gradle
+++ b/SampleCommunicator/build.gradle
@@ -36,24 +36,19 @@ java {
 
 dependencies {
 
-	implementation (group: 'ch.smartgridready', name: 'commhandler4modbus', version: '1.0.0') {
+	implementation (group: 'ch.smartgridready', name: 'commhandler4modbus', version: '1.0.1') {
         exclude group: 'SGrJava.InterfaceFactory', module: 'emfEI4Modbus'
     }
 
 	implementation group: 'ch.smartgridready', name: 'easymodbus', version: '1.0.0'
     implementation group: 'ch.smartgridready', name: 'sgr-driver-api', version: '1.0.0'
-	
-	implementation group: 'io.github.java-native', name: 'jssc', version: '2.9.2'	
-    implementation group: 'org.eclipse.emf', name: 'org.eclipse.emf.ecore', version: '2.24.0'   
-    implementation group: 'org.eclipse.emf', name: 'org.eclipse.emf.common', version: '2.24.0'
     
     // Logging
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.18.0'
 
+    // Reactive Java
     implementation group: 'io.reactivex.rxjava3', name: 'rxjava', version: '3.1.5'
-    
-
 
     // Use JUnit test framework
     implementation  group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.1'


### PR DESCRIPTION
Do so we can load EI-XML according to the most current XSD-Versions.

Also removed some unnecessary dependencies related to the modbus driver.